### PR TITLE
Added displayName to the flag match

### DIFF
--- a/src/test/java/org/reactome/server/tools/diagram/exporter/raster/diagram/DiagramRendererTest.java
+++ b/src/test/java/org/reactome/server/tools/diagram/exporter/raster/diagram/DiagramRendererTest.java
@@ -220,8 +220,16 @@ public class DiagramRendererTest {
 	@Test
 	public void testChemicalDrug() {
 		final RasterArgs args = new RasterArgs("R-HSA-2894858", "png");
-		args.setQuality(10);
+//		args.setQuality(10);
 		args.setSelected(Collections.singleton("113582"));
+		TestUtils.render(args, null);
+	}
+
+	@Test
+	public void testMoreFlag() {
+		final RasterArgs args = new RasterArgs("1368108", "png");
+//		args.setQuality(10);
+		args.setFlags(Collections.singleton("KLF15"));
 		TestUtils.render(args, null);
 	}
 }


### PR DESCRIPTION
Flags were returning the first element in the graph that matched (dbId, stId, genenames or identifier) the flag term and its ancestorts.
Now it will return all of the elements that match the term (dbId, stId, genenames, identifier or displayName) and their ancestors.